### PR TITLE
Attempt to fix furnace losing contents upon rotation

### DIFF
--- a/src/main/java/cubex2/mods/morefurnaces/blocks/BlockMoreFurnaces.java
+++ b/src/main/java/cubex2/mods/morefurnaces/blocks/BlockMoreFurnaces.java
@@ -230,24 +230,18 @@ public class BlockMoreFurnaces extends Block implements ITileEntityProvider
 
     @Override
     public boolean rotateBlock(World world, BlockPos pos, EnumFacing axis) {
-
-        IBlockState state = world.getBlockState(pos);
         TileEntity te = world.getTileEntity(pos);
-        if(te != null && te instanceof TileEntityIronFurnace) {
-            if(axis == EnumFacing.UP || axis == EnumFacing.DOWN) {
-                return false;
-            }
-            else {
-                if(world.isRemote) {
-                    ((TileEntityIronFurnace) te).setFacing((byte) axis.ordinal());
-                    world.notifyBlockUpdate(pos, state, state, 3);
-
-                    return true;
-                }
-            }
+        if(!(te instanceof TileEntityIronFurnace))
+        {
+            return false;
         }
 
-        return false;
+        TileEntityIronFurnace tef = (TileEntityIronFurnace) te;
+        EnumFacing newFacing = EnumFacing.getFront(tef.getFacing()).rotateY();
+        tef.setFacing((byte) newFacing.ordinal());
+        IBlockState state = world.getBlockState(pos);
+        world.setBlockState(pos, state.withProperty(FACING, newFacing));
+        return true;
     }
 
     @Override
@@ -284,7 +278,6 @@ public class BlockMoreFurnaces extends Block implements ITileEntityProvider
 
         super.breakBlock(world, pos, state);
     }
-
 
     @Override
     @SideOnly(Side.CLIENT)

--- a/src/main/java/cubex2/mods/morefurnaces/blocks/BlockMoreFurnaces.java
+++ b/src/main/java/cubex2/mods/morefurnaces/blocks/BlockMoreFurnaces.java
@@ -229,6 +229,28 @@ public class BlockMoreFurnaces extends Block implements ITileEntityProvider
     }
 
     @Override
+    public boolean rotateBlock(World world, BlockPos pos, EnumFacing axis) {
+
+        IBlockState state = world.getBlockState(pos);
+        TileEntity te = world.getTileEntity(pos);
+        if(te != null && te instanceof TileEntityIronFurnace) {
+            if(axis == EnumFacing.UP || axis == EnumFacing.DOWN) {
+                return false;
+            }
+            else {
+                if(world.isRemote) {
+                    ((TileEntityIronFurnace) te).setFacing((byte) axis.ordinal());
+                    world.notifyBlockUpdate(pos, state, state, 3);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
     public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand)
     {
         return super.getStateForPlacement(world, pos, facing, hitX, hitY, hitZ, meta, placer, hand).withProperty(FACING, placer.getHorizontalFacing().getOpposite());

--- a/src/main/java/cubex2/mods/morefurnaces/tileentity/TileEntityIronFurnace.java
+++ b/src/main/java/cubex2/mods/morefurnaces/tileentity/TileEntityIronFurnace.java
@@ -20,8 +20,10 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -487,6 +489,11 @@ public class TileEntityIronFurnace extends TileEntity implements ITickable
                 break;
             }
         }
+    }
+
+    @Override
+    public boolean shouldRefresh(World world, BlockPos pos, IBlockState oldState, IBlockState newSate) {
+        return oldState.getBlock() != newSate.getBlock();
     }
 
     @Override


### PR DESCRIPTION
Attempts to fix furnaces losing contents upon rotation. Rotation tested with Thermal Expansion Crescent Hammer. 
This is not perfect as it opens the GUI on the same click as the rotation. Maybe solved with using shift right click for rotation?
I am putting this forward for others to take a look at, and see if they have a better method to fix the issue.